### PR TITLE
Fix tag related documentation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -209,7 +209,7 @@ You can list any number of tags greater than 0, and all of them will be added to
 
 Duplicate tags or already-present tags will not affect the candidate.
 
-Format: `tag INDEX [t/TAG]…​`
+Format: `tag INDEX t/TAG [t/TAG]…​`
 
 * At least one tag must be provided.
 
@@ -223,7 +223,7 @@ If tag command is successfully executed, the app will display the candidate with
 
 Deletes existing tag(s) from a candidate's list of tags
 
-Format: `delete_tag INDEX [t/TAG]…​`
+Format: `delete_tag INDEX t/TAG [t/TAG]…​`
 
 * At least one tag must be provided.
 * The specified tag(s) must be in the candidate's list of tags.
@@ -450,7 +450,7 @@ _Details coming soon ..._
 | **Delete**              | `delete INDEX` <br> e.g., `delete 3`                                                                                                                |
 | **Delete job**          | `delete_job INDEX` <br> e.g., `delete_job 3`                                                                                                        |
 | **Delete application**  | `delete_app INDEX` <br> e.g., `delete_app 3`                                                                                                        |
-| **Delete tag**          | `delete_tag INDEX [t/TAG]…​` <br> e.g. `delete_tag 1 t/Exceptional work t/IMO gold`                                                                 |
+| **Delete tag**          | `delete_tag INDEX t/TAG [t/TAG]…​` <br> e.g. `delete_tag 1 t/Exceptional work t/IMO gold`                                                           |
 | **Edit**                | `edit INDEX [n/NAME] [e/EMAIL] [c/COUNTRY] [p/PHONE] [t/TAG]…​` <br> e.g.,`edit 24 n/Johnny Doe e/johnnydoe@gmail.com c/SG`                         |
 | **Edit job**            | `edit_job INDEX [ti/TITLE] [d/DESCRIPTION] [v/VACANCY]` <br> e.g., `edit_job 1 ti/Quantitative Trader d/Must have strong statistics background v/3` |
 | **Get**                 | `get INDEX` <br> e.g., `get 24`                                                                                                                     |
@@ -463,4 +463,4 @@ _Details coming soon ..._
 | **Search applications** | `search_app [e/EMAIL] [ti/TITLE] [s/STATUS]` <br> e.g., `search_app e/alexyeoh@example.com s/PRESCREEN`                                             |
 | **Slots left**          | `slots_left INDEX` <br> e.g., `slots_left 3`                                                                                                        |
 | **Status**              | `status INDEX INTERVIEW_STATUS` <br> e.g., `status 24 IN_PROGRESS`                                                                                  |
-| **Tag**                 | `tag INDEX [t/TAG]…` <br> e.g., `tag 8 t/Exceptional work t/IMO gold t/Male`                                                                        |                                                                                |                                                                                                                              |                                                                                                                                         |
+| **Tag**                 | `tag INDEX t/TAG [t/TAG]…` <br> e.g., `tag 8 t/Exceptional work t/IMO gold t/Male`                                                                  |                                                                                |                                                                                                                              |                                                                                                                                         |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -207,6 +207,8 @@ Appends the tag or tags to a candidate's list of tags.
 
 You can list any number of tags greater than 0, and all of them will be added to the specified **INDEX**. Here, **INDEX** refers to the index number of candidates shown in the displayed candidate list.
 
+Duplicate tags or already-present tags will not affect the candidate.
+
 Format: `tag INDEX [t/TAG]…​`
 
 * At least one tag must be provided.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -62,7 +62,7 @@ HireHub is a **desktop app for managing candidates, optimized for use via a Comm
       - have each domain label start and end with alphanumeric characters
       - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.
   * COUNTRY: must be a valid ISO-3166-1 alpha-2 code which can be found from https://www.iso.org/obp/ui/#search/code/. It is case-sensitive and must be in ALL CAPITALS. Alternatively, you can refer to the appendix for the exact ISO code to use for each country.
-  * TAG: cannot be blank (except in edit command), and only alphanumeric characters and spaces are allowed.
+  * TAG: cannot be blank (except in edit command), and only alphanumeric characters are allowed.
   * COMMENT: can be blank and does not have any constraints.
   * TITLE: cannot be blank and has a character limit of 100.
   * DESCRIPTION: can be blank and does not have any constraints.
@@ -163,9 +163,9 @@ Examples:
 This command edits **name**, **email**, and **country of residence** of the candidate with index 24 to **Johnny Doe**, **johnnydoe@gmail.com**, and **Singapore**, respectively.
 
 
-* `edit 8 n/Jeb Song e/jebsong@gmail.com t/IMO Gold`
+* `edit 8 n/Jeb Song e/jebsong@gmail.com t/IMOGold`
 
-This command edits **name**, **email**, and the tag for **acceptance status** of the candidate with index 8 to **Jeb Song**, **jebsong@gmail.com**, and **IMO Gold**, respectively. Note that the existing tag(s) on this candidate (if any) is/are completely removed and a new tag `IMO Gold` is added.
+This command edits **name**, **email**, and the tag for **acceptance status** of the candidate with index 8 to **Jeb Song**, **jebsong@gmail.com**, and **IMOGold**, respectively. Note that the existing tag(s) on this candidate (if any) is/are completely removed and a new tag `IMOGold` is added.
 
 ---
 
@@ -215,7 +215,7 @@ Format: `tag INDEX t/TAG [t/TAG]…​`
 
 Examples:
 * `tag 24 t/smart` adds the tag "smart" to the candidate with index 24.
-* `tag 8 t/Exceptional work t/IMO gold t/Male` adds the tags "Exceptional work", "IMO gold" and "Male" to the candidate with index 8.
+* `tag 8 t/ExceptionalWork t/IMOGold t/Male` adds the tags "ExceptionalWork", "IMOGold" and "Male" to the candidate with index 8.
 
 If tag command is successfully executed, the app will display the candidate with the new tags.
 
@@ -229,7 +229,7 @@ Format: `delete_tag INDEX t/TAG [t/TAG]…​`
 * The specified tag(s) must be in the candidate's list of tags.
 
 Example:
-* `delete_tag 1 t/Exceptional work t/IMO gold` removes these tags from the 1st candidate displayed.
+* `delete_tag 1 t/ExceptionalWork t/IMOGold` removes these tags from the 1st candidate displayed.
 
 ### Change status of an application: `status`
 
@@ -428,7 +428,7 @@ _Details coming soon ..._
 **A**: Install the app in the other computer and overwrite the empty data files it creates with the files that contain the data of your previous HireHub home folder.
 
 **Q**: What is the difference between `edit` and `tag`?<br>
-**A**: `edit` will overwrite any current tags with new tags, while `tag` will append the new tags to the current ones. For example, suppose that John is candidate 1 with tags `Internal` and `Waitlist`. `edit 1 t/Quant Researcher` will change John's tags to just `Quant Researcher`, while `tag t/Quant Researcher` will change John's tags to `Internal`, `Waitlist` and `Quant Researcher`.
+**A**: `edit` will overwrite any current tags with new tags, while `tag` will append the new tags to the current ones. For example, suppose that John is candidate 1 with tags `Internal` and `Waitlist`. `edit 1 t/QuantResearcher` will change John's tags to just `QuantResearcher`, while `tag t/QuantResearcher` will change John's tags to `Internal`, `Waitlist` and `QuantResearcher`.
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -450,7 +450,7 @@ _Details coming soon ..._
 | **Delete**              | `delete INDEX` <br> e.g., `delete 3`                                                                                                                |
 | **Delete job**          | `delete_job INDEX` <br> e.g., `delete_job 3`                                                                                                        |
 | **Delete application**  | `delete_app INDEX` <br> e.g., `delete_app 3`                                                                                                        |
-| **Delete tag**          | `delete_tag INDEX t/TAG [t/TAG]…​` <br> e.g. `delete_tag 1 t/Exceptional work t/IMO gold`                                                           |
+| **Delete tag**          | `delete_tag INDEX t/TAG [t/TAG]…​` <br> e.g. `delete_tag 1 t/ExceptionalWork t/IMOGold`                                                             |
 | **Edit**                | `edit INDEX [n/NAME] [e/EMAIL] [c/COUNTRY] [p/PHONE] [t/TAG]…​` <br> e.g.,`edit 24 n/Johnny Doe e/johnnydoe@gmail.com c/SG`                         |
 | **Edit job**            | `edit_job INDEX [ti/TITLE] [d/DESCRIPTION] [v/VACANCY]` <br> e.g., `edit_job 1 ti/Quantitative Trader d/Must have strong statistics background v/3` |
 | **Get**                 | `get INDEX` <br> e.g., `get 24`                                                                                                                     |
@@ -463,4 +463,4 @@ _Details coming soon ..._
 | **Search applications** | `search_app [e/EMAIL] [ti/TITLE] [s/STATUS]` <br> e.g., `search_app e/alexyeoh@example.com s/PRESCREEN`                                             |
 | **Slots left**          | `slots_left INDEX` <br> e.g., `slots_left 3`                                                                                                        |
 | **Status**              | `status INDEX INTERVIEW_STATUS` <br> e.g., `status 24 IN_PROGRESS`                                                                                  |
-| **Tag**                 | `tag INDEX t/TAG [t/TAG]…` <br> e.g., `tag 8 t/Exceptional work t/IMO gold t/Male`                                                                  |                                                                                |                                                                                                                              |                                                                                                                                         |
+| **Tag**                 | `tag INDEX t/TAG [t/TAG]…` <br> e.g., `tag 8 t/ExceptionalWork t/IMOGold t/Male`                                                                    |                                                                                |                                                                                                                              |                                                                                                                                         |

--- a/src/main/java/seedu/hirehub/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/hirehub/logic/commands/DeleteTagCommand.java
@@ -27,6 +27,7 @@ public class DeleteTagCommand extends Command {
             + "by the index number used in the last person listing.\n"
             + "At least one tag must be present. All tags specified will be removed.\n"
             + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_TAG + "TAG "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TAG + "INTERNAL " + PREFIX_TAG + "WAITLIST";

--- a/src/main/java/seedu/hirehub/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/hirehub/logic/commands/TagCommand.java
@@ -28,6 +28,7 @@ public class TagCommand extends Command {
             + "Existing tags will not be overwritten by the input.\n"
             + "At least one tag must be present.\n"
             + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_TAG + "TAG " 
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TAG + "INTERNAL " + PREFIX_TAG + "WAITLIST";


### PR DESCRIPTION
In documentation, removes spaces in tags to match code, changes arity of tag commands to match code, and mention that duplicate tags have no effect

Fix #166, fix #167, fix #186
